### PR TITLE
ci: upgrade GitHub Actions to Node.js 24-compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,15 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-python-${{ matrix.python-version }}-pip-${{ hashFiles('**/requirements.txt', 'pyproject.toml') }}
@@ -49,9 +49,9 @@ jobs:
 
     - name: Upload coverage reports
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
@@ -59,10 +59,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
           - arch: arm64
             runner: windows-11-arm
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Build EXE
@@ -35,7 +35,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path build-out | Out-Null
           $ver = "${{ github.ref_name }}"
           Copy-Item "dist/map-tiles-downloader.exe" ("build-out/map-tiles-downloader-Windows-${{ matrix.arch }}-" + $ver + ".exe")
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: windows-${{ matrix.arch }}-exe
           path: build-out/*
@@ -49,8 +49,8 @@ jobs:
       matrix:
         os: [macos-13, macos-14]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Build binary and DMG
@@ -65,7 +65,7 @@ jobs:
           mkdir -p dmgroot build-out
           cp dist/map-tiles-downloader dmgroot/
           hdiutil create -volname "Map Tiles Downloader" -srcfolder dmgroot -ov -format UDZO "build-out/map-tiles-downloader-macOS-$arch-$ver.dmg"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: macos-dmg-${{ matrix.os }}
           path: build-out/*
@@ -89,15 +89,15 @@ jobs:
             appimage_arch: aarch64
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-${{ matrix.arch }}-pip-${{ hashFiles('**/requirements.txt', 'pyproject.toml') }}
@@ -105,7 +105,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.arch }}-pip-
 
       - name: Cache PyInstaller
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pyinstaller
           key: ${{ runner.os }}-${{ matrix.arch }}-pyinstaller-${{ hashFiles('**/requirements.txt', 'pyproject.toml') }}
@@ -204,7 +204,7 @@ jobs:
               dist/map-tiles-downloader=/usr/bin/map-tiles-downloader
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: linux-${{ matrix.arch }}-artifacts
           path: build-out/*
@@ -213,8 +213,8 @@ jobs:
     name: Build sdist and wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Build dists
@@ -224,7 +224,7 @@ jobs:
           python -m build
       - name: Upload package artifacts
         if: ${{ github.actor != 'nektos/act' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: python-dists
           path: dist/*
@@ -237,12 +237,12 @@ jobs:
     needs: [build-windows, build-macos, build-linux, build-packages]
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: ./artifacts
           merge-multiple: true
       - name: Create Release and upload assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}


### PR DESCRIPTION
## Problem

The CI pipeline is failing / at risk of failing. Investigation of the latest runs showed:

- All test/lint jobs were green **except** `test (ubuntu-latest, 3.9)`, which died on `actions/checkout@v4` with a transient GitHub `500 Internal Server Error` — an infra blip, not a code bug.
- Every job carried the annotation: **Node.js 20 actions were force-migrated to Node.js 24 on June 2, 2026**, and Node 20 is removed from runners on **Sept 16, 2026**. All pinned action majors still ran on Node 20, which is the durable root cause of breakage going forward.

## Fix

Bump every action to its first Node.js 24-compatible major:

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v5 |
| actions/setup-python | v5 | v6 |
| actions/cache | v4 | v5 |
| actions/upload-artifact | v4 | v5 |
| actions/download-artifact | v4 | v5 |
| codecov/codecov-action | v4 | v5 |
| softprops/action-gh-release | v2 | v3 |

Also renamed the deprecated codecov `file:` input to `files:` (v5 breaking change).

No source code changed — only `.github/workflows/{ci,release}.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)