### PR TITLE
Bump to 1.3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mt-downloader"
-version = "1.3.6"
+version = "1.3.7"
 description = "Fast interactive Meshtastic and MeshCore maps downloader"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/map_tiles_downloader/__init__.py
+++ b/src/map_tiles_downloader/__init__.py
@@ -2,4 +2,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "1.3.6"
+__version__ = "1.3.7"


### PR DESCRIPTION
Patch version bump 1.3.6 → 1.3.7 in `pyproject.toml` and `src/map_tiles_downloader/__init__.py`, ahead of tagging `v1.3.7` to trigger the release pipeline.

Includes the recent CI Node.js 24 action upgrades already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)